### PR TITLE
Add AI assistance section to user guide.

### DIFF
--- a/docs/guide/ai-assistance.md
+++ b/docs/guide/ai-assistance.md
@@ -1,0 +1,12 @@
+## AI assistance
+
+[JMeter DSL Skills](https://github.com/abstracta/jmeter-dsl-skills) is a set of AI agent skills for JMeter .Net DSL that will help you throughout the entire performance testing workflow.
+
+Currently, you can use it to:
+
+- **Write DSL code**: get help generating test plans, samplers, assertions, and more from natural language descriptions. Note that code generation currently targets the Java DSL — you may need to adapt the output to .NET syntax.
+- **Navigate the documentation**: ask questions about DSL features, configuration options, and best practices and get answers grounded in the DSL docs
+
+In the future, it will also support triggering test executions, analyzing results, and configuring projects — making it a single AI interface for the full performance testing lifecycle.
+
+To get started, follow the setup instructions in the [JMeter DSL Skills repository](https://github.com/abstracta/jmeter-dsl-skills).

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -17,6 +17,7 @@ For an intro to JMeter concepts and components, you can check [JMeter official d
 <!-- @include: setup.md -->
 <!-- @include: simple-test-plan.md -->
 <!-- @include: scale/index.md -->
+<!-- @include: ai-assistance.md -->
 <!-- @include: thread-groups/index.md -->
 <!-- @include: debugging/index.md -->
 <!-- @include: reporting/index.md -->


### PR DESCRIPTION
- Adds a new docs/guide/ai-assistance.md section referencing [JMeter DSL Skills](https://github.com/abstracta/jmeter-dsl-skills)
- Places the section after "Run at scale" so users discover it once familiar with the core workflow
- Describes current capabilities (DSL code writing, docs navigation) and the future roadmap (triggering executions, analyzing results, configuring projects)